### PR TITLE
Fix: restore Scene code splitting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
+import { lazy, Suspense } from 'react';
 import './App.scss';
-import Scene from './components/three/Scene';
 import Navbar from './components/sections/Navbar';
 import Hero from './components/sections/Hero';
 import About from './components/sections/About';
@@ -8,10 +8,14 @@ import Services from './components/sections/Services';
 import Contact from './components/sections/Contact';
 import Footer from './components/sections/Footer';
 
+const Scene = lazy(() => import('./components/three/Scene'));
+
 function App() {
   return (
     <div className="App">
-      <Scene />
+      <Suspense fallback={null}>
+        <Scene />
+      </Suspense>
       <Navbar />
       <main>
         <Hero />

--- a/src/components/three/InfinityField.tsx
+++ b/src/components/three/InfinityField.tsx
@@ -306,11 +306,25 @@ export default function InfinityField({ reducedMotion = false, opacity = 1, scro
     () => ({
       uTime: { value: 0 },
       uPixelRatio: { value: Math.min(gl.getPixelRatio(), 2) },
-      uOpacity: { value: opacity },
-      uScroll: { value: scroll },
+      uOpacity: { value: 1 },
+      uScroll: { value: 0 },
     }),
     [gl],
   );
+
+  useEffect(() => {
+    currentOpacity.current = opacity;
+    if (materialRef.current) {
+      materialRef.current.uniforms.uOpacity.value = opacity;
+    }
+  }, [opacity]);
+
+  useEffect(() => {
+    currentScroll.current = scroll;
+    if (materialRef.current) {
+      materialRef.current.uniforms.uScroll.value = scroll;
+    }
+  }, [scroll]);
 
   useFrame((state, delta) => {
     if (reducedMotion) {


### PR DESCRIPTION
## Summary

Fixes #54.

- Restores lazy loading for `Scene` from `src/App.tsx` so the Three/WebGL stack stays out of the initial app chunk.
- Removes the `react-hooks/exhaustive-deps` warning in `InfinityField` by keeping uniforms stable and updating opacity/scroll through effects and the frame loop.

## Verification

- `npm run lint`
- `npm run acceptance:test`

Build output now splits the scene again:

- main app chunk: ~240 kB minified
- `Scene`: separate chunk
- `InfinityField`: separate chunk
- `react-three-fiber` / Three stack: separate chunk
