### PR TITLE
fix(footer): restore required contact and social links

### DIFF
--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -6,7 +6,9 @@ const socials = [
   { platform: 'github', url: 'https://github.com/ever-guild', label: 'GitHub' },
   { platform: 'x', url: 'https://x.com/ever_guild_net', label: 'X' },
   { platform: 'linkedin', url: 'https://www.linkedin.com/company/ever-guild/', label: 'LinkedIn' },
+  { platform: 'telegram', url: 'https://t.me/everguild', label: 'Telegram' },
   { platform: 'upwork', url: 'https://www.upwork.com/agencies/everguild/', label: 'Upwork' },
+  { platform: 'email', url: 'mailto:in@ever-guild.net', label: 'Email' },
 ];
 
 export const Footer = React.memo(function Footer() {

--- a/src/components/ui/SocialIcon.tsx
+++ b/src/components/ui/SocialIcon.tsx
@@ -8,6 +8,7 @@ import {
   FaEnvelope,
   FaGlobe,
   FaLink,
+  FaTelegram,
 } from 'react-icons/fa6';
 import './SocialIcon.scss';
 
@@ -19,6 +20,7 @@ const iconMap: Record<string, IconType> = {
   upwork: FaUpwork,
   email: FaEnvelope,
   mail: FaEnvelope,
+  telegram: FaTelegram,
   website: FaGlobe,
   default: FaLink,
 };

--- a/tests/acceptance/content.spec.ts
+++ b/tests/acceptance/content.spec.ts
@@ -116,4 +116,24 @@ test.describe('landing page content', () => {
       expect(body).toContain('skipWaiting');
     }
   });
+
+  test('footer contains all required social and contact links', async ({ page }) => {
+    await page.goto('/');
+
+    const footer = page.locator('.footer');
+    await expect(footer).toBeVisible();
+
+    const expectedLinks = [
+      'https://github.com/ever-guild',
+      'https://x.com/ever_guild_net',
+      'https://www.linkedin.com/company/ever-guild/',
+      'https://t.me/everguild',
+      'https://www.upwork.com/agencies/everguild/',
+      'mailto:in@ever-guild.net',
+    ];
+
+    for (const url of expectedLinks) {
+      await expect(footer.locator(`a[href="${url}"]`)).toBeVisible();
+    }
+  });
 });


### PR DESCRIPTION
Closes #75.

This PR restores the required Telegram and email contact paths (https://t.me/everguild and mailto:in@ever-guild.net) in the footer, and adds an E2E acceptance test to check all required external links.


**Before**
<img width="646" height="216" alt="image" src="https://github.com/user-attachments/assets/0fae754f-f863-4961-a829-a544763c6f67" />

**After**
<img width="646" height="216" alt="image" src="https://github.com/user-attachments/assets/bc024784-3d9f-4a12-9747-fa927146b3ac" />
