### PR TITLE
[codex] Restore dependency versions from main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@ever-guild/site",
       "version": "1.0.0",
       "dependencies": {
-        "lucide-react": "^1.17.0",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6",
+        "lucide-react": "^1.21.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "react-icons": "^5.6.0"
       },
       "devDependencies": {
@@ -19,9 +19,9 @@
         "@playwright/test": "^1.61.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.2",
-        "baseline-browser-mapping": "^2.10.32",
-        "eslint": "^10.4.0",
+        "@vitejs/plugin-react": "^6.0.3",
+        "baseline-browser-mapping": "^2.10.38",
+        "eslint": "^10.5.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "sass": "^1.101.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "vt:check": "node .github/actions/virustotal-url-check/check-url.mjs"
   },
   "dependencies": {
-    "lucide-react": "^1.17.0",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6",
+    "lucide-react": "^1.21.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "react-icons": "^5.6.0"
   },
   "overrides": {
@@ -30,9 +30,9 @@
     "@playwright/test": "^1.61.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.2",
-    "baseline-browser-mapping": "^2.10.32",
-    "eslint": "^10.4.0",
+    "@vitejs/plugin-react": "^6.0.3",
+    "baseline-browser-mapping": "^2.10.38",
+    "eslint": "^10.5.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "sass": "^1.101.0",


### PR DESCRIPTION
## Summary
- Restore dependency ranges that PR #74 accidentally downgraded.
- Regenerate `package-lock.json` from the corrected `package.json`.

## Restored versions
- `lucide-react` to `^1.21.0`
- `react` to `^19.2.7`
- `react-dom` to `^19.2.7`
- `@vitejs/plugin-react` to `^6.0.3`
- `baseline-browser-mapping` to `^2.10.38`
- `eslint` to `^10.5.0`

## Checks
- `npm run lint`
- `npm run acceptance:test`
- `npm run lighthouse`

Closes #76